### PR TITLE
style fix in swap modal and version update to 2.0.11

### DIFF
--- a/lib/components/SwapButton/ConfirmationModal.scss
+++ b/lib/components/SwapButton/ConfirmationModal.scss
@@ -71,6 +71,7 @@
         }
 
         .confirm-modal-detail {
+            height: fit-content;
             width: 100%;
             padding-left: 1rem;
             padding-right: 1rem;

--- a/lib/components/SwapButton/Done.scss
+++ b/lib/components/SwapButton/Done.scss
@@ -20,7 +20,7 @@
             display: flex;
             align-items: center;
             justify-content: center;
-            font-size: 2.5rem;
+            font-size: 5rem;
             color: var(--primary-color);
         }
         .done-text {
@@ -28,30 +28,30 @@
             font-size: 1.25rem;
             font-weight: bold;
             text-align: center;
+            margin-bottom: 2rem;
         }
         .done-modal-images {
             display: flex;
             align-items: center;
             padding-top: 0.25rem;
             .pay-image {
-                border-color: var(--background-color);
-                width: 2.25rem;
-                height: 2.25rem;
+                border-color: var(--modal-background-color);
+                width: 4rem;
+                height: 4rem;
                 border-radius: 9999px;
                 background-size: contain !important;
-                transform: translateX(0.2rem);
-                border-width: 1px;
+                transform: translateX(0.75rem);
+                border-width: 5px;
                 border-style: solid;
             }
             .receive-image {
-                border-color: var(--background-color);
-
-                width: 2.25rem;
-                height: 2.25rem;
+                border-color: var(--modal-background-color);
+                width: 4rem;
+                height: 4rem;
                 border-radius: 9999px;
                 background-size: contain !important;
                 transform: translateX(-0.2rem);
-                border-width: 1px;
+                border-width: 5px;
                 border-style: solid;
             }
         }

--- a/lib/components/SwapButton/SwapButton.scss
+++ b/lib/components/SwapButton/SwapButton.scss
@@ -13,15 +13,17 @@
             border-color: var(--border-color);
             position: fixed;
             width: 100%;
-            height: 80vh;
-            max-height: 400px;
-            padding: 0.25rem;
-            padding-top: 0.5rem;
+            max-height: 430px;
+            height: 100%;
+
+            padding: 0.5rem 0.25rem;
             display: flex;
+            align-items: center;
+            justify-content: center;
             flex-direction: column;
             box-shadow: 0px 0px 5px rgba(0, 0, 0, 0.05);
-            border-top-left-radius: 0.75rem;
-            border-top-right-radius: 0.75rem;
+            border-top-left-radius: 1rem;
+            border-top-right-radius: 1rem;
             bottom: 0;
             left: 0;
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@mytonswap/widget",
     "description": "MyTonSwap Widget - Easy to use swap widget for React on TON Blockchain",
-    "version": "2.0.9",
+    "version": "2.0.10",
     "type": "module",
     "author": {
         "name": "MyTonSwap",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@mytonswap/widget",
     "description": "MyTonSwap Widget - Easy to use swap widget for React on TON Blockchain",
-    "version": "2.0.10",
+    "version": "2.0.11",
     "type": "module",
     "author": {
         "name": "MyTonSwap",


### PR DESCRIPTION
This pull request includes several updates to the styling of the `SwapButton` component and a version bump in `package.json`. The most important changes include adjustments to modal and button styles, as well as an increase in the version number.

Styling updates:

* [`lib/components/SwapButton/ConfirmationModal.scss`](diffhunk://#diff-5280dd6bde282fb3d4fdb1e2bedb0542f6b479de743ada9c55705ac6c0a93f0bR74): Adjusted the height of `.confirm-modal-detail` to fit content.
* [`lib/components/SwapButton/Done.scss`](diffhunk://#diff-48624ecaf826e9e1139880dd3fab276d70211bf631253765bed45763254ebd80L23-R54): Increased the font size of the main text, added margin to `.done-text`, and updated the styles of `.pay-image` and `.receive-image` to have larger dimensions and border width.
* [`lib/components/SwapButton/SwapButton.scss`](diffhunk://#diff-23ded20ef17a3d35d42af94db0d558fe92f67e3d2fd8bd493b962c1975c9aee7L16-R26): Modified the height and padding of the button, added alignment and centering styles, and increased the border radius of the top corners.

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the version from `2.0.10` to `2.0.11`.