### PR TITLE
fix hash by changing the conversion to hex and version upgraded to 2.0.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@mytonswap/widget",
     "description": "MyTonSwap Widget - Easy to use swap widget for React on TON Blockchain",
-    "version": "2.0.12",
+    "version": "2.0.13",
     "type": "module",
     "author": {
         "name": "MyTonSwap",


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file. The change updates the version of the `@mytonswap/widget` package from `2.0.12` to `2.0.13`.