### PR TITLE
improve the consistency of units used across the application

### DIFF
--- a/lib/components/Header/SettingPopover.scss
+++ b/lib/components/Header/SettingPopover.scss
@@ -23,7 +23,7 @@
             position: fixed;
             display: flex;
             height: fit-content;
-            min-width: 250px;
+            min-width: 15.625rem;
             bottom: 0;
             right: 0;
             border: 1px solid var(--border-color);
@@ -31,7 +31,7 @@
             border-top-left-radius: 1rem;
             border-top-right-radius: 1rem;
             padding: 1rem;
-            gap: 12px;
+            gap: 0.75rem;
             flex-direction: column;
             .popover-header {
                 display: flex;
@@ -44,7 +44,7 @@
             }
             @media screen and (min-width: 768px) {
                 & {
-                    max-width: 520px;
+                    max-width: 32.5rem;
                     border-radius: 1rem;
                 }
             }
@@ -62,7 +62,7 @@
         box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
         width: 100%;
         height: 100%;
-        min-width: 250px;
+        min-width: 15.625rem;
         height: fit-content;
     }
 }
@@ -76,7 +76,7 @@
 @media screen and (min-width: 768px) {
     .mytonswap-app {
         .popover {
-            min-width: 320px;
+            min-width: 20rem;
         }
     }
 }

--- a/lib/components/Swap/Swap.scss
+++ b/lib/components/Swap/Swap.scss
@@ -69,22 +69,22 @@
         border-color: var(--swap-container-border-color);
         border-width: 1px;
         border-style: solid;
-        max-width: 350px;
+        max-width: 21.875rem;
         padding: 0.5rem;
         border-radius: 1rem;
         overflow: hidden;
     }
     @media screen and (min-width: 768px) {
         .container {
-            max-width: 450px;
-            width: 450px;
+            max-width: 28.125rem;
+            width: 28.125rem;
             padding: 0.75rem;
         }
     }
     @media screen and (min-width: 1024px) {
         .container {
-            max-width: calc(550px + 24px);
-            width: calc(550px + 24px);
+            max-width: calc(34.375rem + 24px);
+            width: calc(34.375rem + 24px);
         }
     }
 

--- a/lib/components/SwapButton/SwapButton.scss
+++ b/lib/components/SwapButton/SwapButton.scss
@@ -19,7 +19,7 @@
             border-color: var(--border-color);
             position: fixed;
             width: 100%;
-            max-height: 430px;
+            max-height: 26.875rem;
             height: 100%;
 
             padding: 0.5rem 0.25rem;
@@ -35,17 +35,17 @@
 
             @media (min-width: 768px) {
                 width: 90%;
-                max-width: 450px;
+                max-width: 28.125rem;
                 height: 100%;
                 max-height: 80%;
-                max-height: 380px;
+                max-height: 23.75rem;
                 box-shadow: 0 0px 10px rgba(0, 0, 0, 0.05);
                 border-radius: 0.75rem;
             }
 
             @media (min-width: 1024px) {
-                max-width: 520px;
-                width: 520px;
+                max-width: 32.5rem;
+                width: 32.5rem;
             }
         }
     }
@@ -74,7 +74,7 @@
             .modal-container-inner {
                 height: 100%;
                 max-height: 80%;
-                max-height: 400px;
+                max-height: 25rem;
                 border-radius: 1rem;
             }
         }
@@ -91,7 +91,7 @@
             .modal-container-inner {
                 height: 100%;
                 max-height: 80%;
-                max-height: 420px;
+                max-height: 26.25rem;
                 border-radius: 1rem;
             }
         }

--- a/lib/components/SwapCard/CardDialog.scss
+++ b/lib/components/SwapCard/CardDialog.scss
@@ -28,10 +28,10 @@
 
             @media (min-width: 768px) {
                 width: 90%;
-                max-width: 550px;
+                max-width: 34.375rem;
                 height: auto;
                 max-height: 70dvh;
-                min-height: 350px;
+                min-height: 21.875rem;
                 box-shadow: 0 0px 10px rgba(0, 0, 0, 0.05);
                 border-radius: 1rem;
             }

--- a/lib/components/SwapDetails/SwapDetails.scss
+++ b/lib/components/SwapDetails/SwapDetails.scss
@@ -18,7 +18,7 @@
             align-items: center;
             justify-content: space-between;
             width: 100%;
-            min-height: 52px;
+            min-height: 3.25rem;
             font-size: var(--font-size-sm);
             font-weight: 500;
 

--- a/lib/components/icons/Setting.tsx
+++ b/lib/components/icons/Setting.tsx
@@ -13,9 +13,9 @@ const Setting = (props: SVGProps<SVGSVGElement>) => {
             <path
                 d="M3 8L15 8M15 8C15 9.65686 16.3431 11 18 11C19.6569 11 21 9.65685 21 8C21 6.34315 19.6569 5 18 5C16.3431 5 15 6.34315 15 8ZM9 16L21 16M9 16C9 17.6569 7.65685 19 6 19C4.34315 19 3 17.6569 3 16C3 14.3431 4.34315 13 6 13C7.65685 13 9 14.3431 9 16Z"
                 stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
             />
         </svg>
     );

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@mytonswap/widget",
     "description": "MyTonSwap Widget - Easy to use swap widget for React on TON Blockchain",
-    "version": "2.0.13",
+    "version": "2.0.14",
     "type": "module",
     "author": {
         "name": "MyTonSwap",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@mytonswap/widget",
     "description": "MyTonSwap Widget - Easy to use swap widget for React on TON Blockchain",
-    "version": "2.0.14",
+    "version": "2.0.15",
     "type": "module",
     "author": {
         "name": "MyTonSwap",


### PR DESCRIPTION
This pull request includes several changes to the SCSS files to improve the consistency of units used across the application, as well as a small update to the `Setting` icon component and a version bump in the `package.json` file.

### SCSS Unit Consistency Improvements:

* [`lib/components/Header/SettingPopover.scss`](diffhunk://#diff-9b1836ffb41d636f7ffbb3455e821c3aeecd2d5b9489744ee0ef92ad7de223f9L26-R34): Updated various `min-width`, `max-width`, and `gap` properties to use `rem` units instead of `px`. [[1]](diffhunk://#diff-9b1836ffb41d636f7ffbb3455e821c3aeecd2d5b9489744ee0ef92ad7de223f9L26-R34) [[2]](diffhunk://#diff-9b1836ffb41d636f7ffbb3455e821c3aeecd2d5b9489744ee0ef92ad7de223f9L47-R47) [[3]](diffhunk://#diff-9b1836ffb41d636f7ffbb3455e821c3aeecd2d5b9489744ee0ef92ad7de223f9L65-R65) [[4]](diffhunk://#diff-9b1836ffb41d636f7ffbb3455e821c3aeecd2d5b9489744ee0ef92ad7de223f9L79-R79)
* [`lib/components/Swap/Swap.scss`](diffhunk://#diff-1d0556178ac4b6875561a3ee12116fae987a8cdc4060283cc5b997b5dbe94f23L72-R87): Changed `max-width` and `width` properties to `rem` units for better scalability.
* [`lib/components/SwapButton/SwapButton.scss`](diffhunk://#diff-23ded20ef17a3d35d42af94db0d558fe92f67e3d2fd8bd493b962c1975c9aee7L22-R22): Updated `max-height`, `max-width`, and `width` properties to use `rem` units. [[1]](diffhunk://#diff-23ded20ef17a3d35d42af94db0d558fe92f67e3d2fd8bd493b962c1975c9aee7L22-R22) [[2]](diffhunk://#diff-23ded20ef17a3d35d42af94db0d558fe92f67e3d2fd8bd493b962c1975c9aee7L38-R48) [[3]](diffhunk://#diff-23ded20ef17a3d35d42af94db0d558fe92f67e3d2fd8bd493b962c1975c9aee7L77-R77) [[4]](diffhunk://#diff-23ded20ef17a3d35d42af94db0d558fe92f67e3d2fd8bd493b962c1975c9aee7L94-R94)
* [`lib/components/SwapCard/CardDialog.scss`](diffhunk://#diff-78cf38c8e9529803f541f63b364d1609bff0b146d46e5d96dae6ba105b551700L31-R34): Converted `max-width` and `min-height` properties to `rem` units.
* [`lib/components/SwapDetails/SwapDetails.scss`](diffhunk://#diff-6cd507bcd1b8a1c7b5dc11e479468b6be0e4e7f49d2d8f0d65feb28848de13f2L21-R21): Changed `min-height` property to use `rem` units.

### Icon Component Update:

* [`lib/components/icons/Setting.tsx`](diffhunk://#diff-32174e2a263ab3bc1b636ffa284e6394cca4d620807d22cad1dc03f117fecea1L16-R18): Corrected the attribute names for `strokeWidth`, `strokeLinecap`, and `strokeLinejoin` to camelCase.

### Version Bump:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the version from `2.0.14` to `2.0.15`.