### PR TITLE
Fix modal size issue for desktop

### DIFF
--- a/lib/components/SwapButton/SwapButton.scss
+++ b/lib/components/SwapButton/SwapButton.scss
@@ -38,7 +38,7 @@
                 max-width: 28.125rem;
                 height: 100%;
                 max-height: 80%;
-                max-height: 23.75rem;
+                max-height: 30rem;
                 box-shadow: 0 0px 10px rgba(0, 0, 0, 0.05);
                 border-radius: 0.75rem;
             }
@@ -70,14 +70,6 @@
 
 @media screen and (min-width: 768px) {
     .mytonswap-app {
-        .modal-container {
-            .modal-container-inner {
-                height: 100%;
-                max-height: 80%;
-                max-height: 25rem;
-                border-radius: 1rem;
-            }
-        }
         .swap-button {
             height: 3.25rem;
             font-size: var(--font-size-md);
@@ -87,14 +79,6 @@
 
 @media screen and (min-width: 1024px) {
     .mytonswap-app {
-        .modal-container {
-            .modal-container-inner {
-                height: 100%;
-                max-height: 80%;
-                max-height: 26.25rem;
-                border-radius: 1rem;
-            }
-        }
         .swap-button {
             height: 3.5rem;
             border-radius: 1rem;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@mytonswap/widget",
     "description": "MyTonSwap Widget - Easy to use swap widget for React on TON Blockchain",
-    "version": "2.0.15",
+    "version": "2.0.16",
     "type": "module",
     "author": {
         "name": "MyTonSwap",


### PR DESCRIPTION
This pull request includes changes to the `SwapButton` component's styling and an update to the package version in `package.json`. The most important changes are:

Styling updates:

* [`lib/components/SwapButton/SwapButton.scss`](diffhunk://#diff-23ded20ef17a3d35d42af94db0d558fe92f67e3d2fd8bd493b962c1975c9aee7L41-R41): Increased the `max-height` of the `.modal-container-inner` to 30rem.
* [`lib/components/SwapButton/SwapButton.scss`](diffhunk://#diff-23ded20ef17a3d35d42af94db0d558fe92f67e3d2fd8bd493b962c1975c9aee7L73-L80): Removed redundant styles for `.modal-container-inner` within media queries for screen widths of 768px and 1024px. [[1]](diffhunk://#diff-23ded20ef17a3d35d42af94db0d558fe92f67e3d2fd8bd493b962c1975c9aee7L73-L80) [[2]](diffhunk://#diff-23ded20ef17a3d35d42af94db0d558fe92f67e3d2fd8bd493b962c1975c9aee7L90-L97)

Package version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L4-R4): Updated the version from `2.0.15` to `2.0.16`.