### PR TITLE
chore: update @mytonswap/sdk version

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "cypress:run": "cypress run --browser chrome"
     },
     "peerDependencies": {
-        "@mytonswap/sdk": "^1.0.9",
+        "@mytonswap/sdk": "^1.0.12",
         "@ton/ton": "^15.0.0",
         "clsx": "^2.1.1",
         "react": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@mytonswap/sdk':
         specifier: ^1.0.9
-        version: 1.0.11(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(typescript@5.6.2)
+        version: 1.0.12(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(typescript@5.6.2)
       '@r2wc/react-to-web-component':
         specifier: ^2.0.3
         version: 2.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -698,8 +698,8 @@ packages:
   '@microsoft/tsdoc@0.15.0':
     resolution: {integrity: sha512-HZpPoABogPvjeJOdzCOSJsXeL/SMCBgBZMVC3X3d7YYp2gf31MfxhUoYUNwf1ERPJOnQc0wkFn9trqI6ZEdZuA==}
 
-  '@mytonswap/sdk@1.0.11':
-    resolution: {integrity: sha512-lDxOQ9RRwuqY/ApiF/QVVAjBc8JQm0IYqjxe04o/wL4jLeAj/E5OpGXcXUckn2JGWmWyKlY1ctFCQsE5Dg64Sw==}
+  '@mytonswap/sdk@1.0.12':
+    resolution: {integrity: sha512-dBxSKyWdKV3P7Gp5+Qs8rsecFCCVZWArpF/XQTA2ZByEm4z9fJYYoVJRSTQfnhSSgml+8og8kZ9nk5a/ucSDbg==}
     peerDependencies:
       '@ton/ton': ^15.0.0
       typescript: ^5.0.0
@@ -4694,7 +4694,7 @@ snapshots:
 
   '@microsoft/tsdoc@0.15.0': {}
 
-  '@mytonswap/sdk@1.0.11(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(typescript@5.6.2)':
+  '@mytonswap/sdk@1.0.12(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(typescript@5.6.2)':
     dependencies:
       '@lifeomic/attempt': 3.1.0
       '@ton/ton': 15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       '@mytonswap/sdk':
-        specifier: ^1.0.9
+        specifier: ^1.0.12
         version: 1.0.12(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(typescript@5.6.2)
       '@r2wc/react-to-web-component':
         specifier: ^2.0.3


### PR DESCRIPTION
This pull request includes updates to the `@mytonswap/sdk` dependency version across multiple files. The changes ensure that the project uses the latest version of this dependency.

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L63-R63): Updated the `@mytonswap/sdk` dependency version from `^1.0.9` to `^1.0.12`.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL13-R13): Updated the `@mytonswap/sdk` dependency version from `1.0.11` to `1.0.12` in the `importers` section.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL701-R702): Updated the `@mytonswap/sdk` dependency version from `1.0.11` to `1.0.12` in the `packages` section.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL4697-R4697): Updated the `@mytonswap/sdk` dependency version from `1.0.11` to `1.0.12` in the `snapshots` section.