### PR TITLE
Standardization of background property & Updating background opacity

### DIFF
--- a/lib/components/Header/SettingPopover.scss
+++ b/lib/components/Header/SettingPopover.scss
@@ -14,7 +14,7 @@
         position: fixed;
         top: 0;
         left: 0;
-        background: rgba(0, 0, 0, 0.3);
+        background: rgba(0, 0, 0, 0.5);
         width: 100%;
         height: 100%;
         .popover {

--- a/lib/components/Header/SlippageSetting.scss
+++ b/lib/components/Header/SlippageSetting.scss
@@ -50,7 +50,7 @@
                     border: 1px solid var(--primary-color);
                 }
                 &.percent-input {
-                    background-color: var(--light-shade-color);
+                    background: var(--light-shade-color);
                     width: 50px;
                 }
 

--- a/lib/components/Swap/Swap.scss
+++ b/lib/components/Swap/Swap.scss
@@ -25,7 +25,7 @@
     button {
         cursor: pointer;
         border: none;
-        background-color: transparent;
+        background: transparent;
         font-family: Inter, sans-serif;
     }
     input {

--- a/lib/components/SwapButton/ConfirmationModal.scss
+++ b/lib/components/SwapButton/ConfirmationModal.scss
@@ -101,7 +101,7 @@
             .confirm-button {
                 cursor: pointer;
                 border-radius: 0.75rem;
-                background-color: var(--primary-color);
+                background: var(--primary-color);
                 width: 100%;
                 height: 3.25rem;
                 color: var(--text-white-color);

--- a/lib/components/SwapButton/SwapButton.scss
+++ b/lib/components/SwapButton/SwapButton.scss
@@ -10,7 +10,7 @@
         top: 0;
         left: 0;
         z-index: 9999999999999999999999999;
-        background-color: rgba(0, 0, 0, 0.1);
+        background: rgba(0, 0, 0, 0.5);
         width: 100%;
         height: 100%;
         overflow: hidden;
@@ -53,7 +53,7 @@
         margin-top: 0.5rem;
         margin-top: 0.75rem;
         border-radius: 0.75rem;
-        background-color: var(--primary-color);
+        background: var(--primary-color);
         width: 100%;
         height: 3.75rem;
         color: var(--text-white-color);

--- a/lib/components/SwapCard/CardDialog.scss
+++ b/lib/components/SwapCard/CardDialog.scss
@@ -4,7 +4,7 @@
         top: 0;
         left: 0;
         z-index: 9999999999999999999999999;
-        background: rgba(0, 0, 0, 0.2);
+        background: rgba(0, 0, 0, 0.5);
         width: 100%;
         height: 100%;
         overflow: hidden;
@@ -95,7 +95,7 @@
 
                 .dialog-search-input {
                     outline: none;
-                    background-color: transparent;
+                    background: transparent;
                     padding-right: 0.25rem;
                     padding-left: 0.25rem;
                     width: 100%;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       '@mytonswap/sdk':
-        specifier: ^1.0.9
+        specifier: ^1.0.12
         version: 1.0.12(@ton/ton@15.1.0(@ton/core@0.59.0(@ton/crypto@3.3.0))(@ton/crypto@3.3.0))(typescript@5.6.2)
       '@r2wc/react-to-web-component':
         specifier: ^2.0.3


### PR DESCRIPTION
This pull request includes several changes to the SCSS files to standardize the usage of the `background` property. The most important changes include modifying `background-color` to `background` and updating the background opacity in various components.

Standardization of `background` property:

* [`lib/components/Header/SlippageSetting.scss`](diffhunk://#diff-3d1fcf17b4c9e2be0a1585248bcdd7d5e7fe0a5315e921bff0564dce58c6c2c7L53-R53): Changed `background-color` to `background` for the `.percent-input` class.
* [`lib/components/Swap/Swap.scss`](diffhunk://#diff-1d0556178ac4b6875561a3ee12116fae987a8cdc4060283cc5b997b5dbe94f23L28-R28): Changed `background-color` to `background` for the `button` element.
* [`lib/components/SwapButton/ConfirmationModal.scss`](diffhunk://#diff-5280dd6bde282fb3d4fdb1e2bedb0542f6b479de743ada9c55705ac6c0a93f0bL104-R104): Changed `background-color` to `background` for the `.confirm-button` class.
* [`lib/components/SwapCard/CardDialog.scss`](diffhunk://#diff-78cf38c8e9529803f541f63b364d1609bff0b146d46e5d96dae6ba105b551700L98-R98): Changed `background-color` to `background` for the `.dialog-search-input` class.

Updating background opacity:

* [`lib/components/Header/SettingPopover.scss`](diffhunk://#diff-9b1836ffb41d636f7ffbb3455e821c3aeecd2d5b9489744ee0ef92ad7de223f9L17-R17): Updated the background opacity from `0.3` to `0.5`.
* [`lib/components/SwapButton/SwapButton.scss`](diffhunk://#diff-23ded20ef17a3d35d42af94db0d558fe92f67e3d2fd8bd493b962c1975c9aee7L13-R13): Updated the background opacity from `0.1` to `0.5`.
* [`lib/components/SwapCard/CardDialog.scss`](diffhunk://#diff-78cf38c8e9529803f541f63b364d1609bff0b146d46e5d96dae6ba105b551700L7-R7): Updated the background opacity from `0.2` to `0.5`.