### PR TITLE
style: Fixed shimmer on pay token & some style fixes 

### DIFF
--- a/lib/components/Header/SettingPopover.scss
+++ b/lib/components/Header/SettingPopover.scss
@@ -8,6 +8,7 @@
             display: flex;
             justify-content: center;
             align-items: center;
+            background: transparent;
         }
     }
     .modal-backdrop {

--- a/lib/components/Swap/Swap.scss
+++ b/lib/components/Swap/Swap.scss
@@ -25,7 +25,6 @@
     button {
         cursor: pointer;
         border: none;
-        background: transparent;
         font-family: Inter, sans-serif;
     }
     input {

--- a/lib/components/Swap/Swap.stories.tsx
+++ b/lib/components/Swap/Swap.stories.tsx
@@ -1,8 +1,8 @@
-import type { Meta, StoryObj } from "@storybook/react";
-import { action } from "@storybook/addon-actions";
+import type { Meta, StoryObj } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
 
-import { Swap } from "./Swap";
-import { tonConnectUi } from "../../../.storybook/preview";
+import { Swap } from './Swap';
+import { tonConnectUi } from '../../../.storybook/preview';
 
 const meta: Meta<typeof Swap> = {
     component: Swap,
@@ -14,8 +14,8 @@ const meta: Meta<typeof Swap> = {
                         args={{
                             ...args.args,
                             tonConnectInstance: tonConnectUi,
-                            onTokenSelect: action("onTokenSelect"),
-                            onSwap: action("onSwap"),
+                            onTokenSelect: action('onTokenSelect'),
+                            onSwap: action('onSwap'),
                         }}
                     />
                 </div>
@@ -52,8 +52,8 @@ export const WithPinnedTokens: Story = {
     args: {
         options: {
             pin_tokens: [
-                "EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c",
-                "EQD4P32U10snNoIavoq6cYPTQR82ewAjO20epigrWRAup54_",
+                'EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c',
+                'EQD4P32U10snNoIavoq6cYPTQR82ewAjO20epigrWRAup54_',
             ],
         },
     },
@@ -63,9 +63,8 @@ export const WithDefaultTokens: Story = {
     args: {
         options: {
             default_pay_token:
-                "EQD4P32U10snNoIavoq6cYPTQR82ewAjO20epigrWRAup54_",
-            default_receive_token:
-                "EQD-cvR0Nz6XAyRBvbhz-abTrRC6sI5tvHvvpeQraV9UAAD7",
+                'EQD4P32U10snNoIavoq6cYPTQR82ewAjO20epigrWRAup54_',
+            default_receive_token: 'RAFF',
         },
     },
 };
@@ -74,9 +73,9 @@ export const WithLockedToken: Story = {
     args: {
         options: {
             default_pay_token:
-                "EQD4P32U10snNoIavoq6cYPTQR82ewAjO20epigrWRAup54_",
+                'EQD4P32U10snNoIavoq6cYPTQR82ewAjO20epigrWRAup54_',
             default_receive_token:
-                "EQD-cvR0Nz6XAyRBvbhz-abTrRC6sI5tvHvvpeQraV9UAAD7",
+                'EQD-cvR0Nz6XAyRBvbhz-abTrRC6sI5tvHvvpeQraV9UAAD7',
             lock_pay_token: true,
         },
     },
@@ -86,13 +85,13 @@ export const WithLockedInput: Story = {
     args: {
         options: {
             default_pay_token:
-                "EQD4P32U10snNoIavoq6cYPTQR82ewAjO20epigrWRAup54_",
+                'EQD4P32U10snNoIavoq6cYPTQR82ewAjO20epigrWRAup54_',
             default_receive_token:
-                "EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c",
+                'EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c',
             lock_pay_token: true,
             lock_receive_token: true,
             lock_input: true,
-            default_pay_amount: "1000000",
+            default_pay_amount: '1000000',
 
             ui_preferences: {
                 disable_provided_text: false,
@@ -111,13 +110,13 @@ export const WithoutRefresh: Story = {
     args: {
         options: {
             default_pay_token:
-                "EQD4P32U10snNoIavoq6cYPTQR82ewAjO20epigrWRAup54_",
+                'EQD4P32U10snNoIavoq6cYPTQR82ewAjO20epigrWRAup54_',
             default_receive_token:
-                "EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c",
+                'EQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM9c',
             lock_pay_token: true,
             lock_receive_token: true,
             lock_input: true,
-            default_pay_amount: "1000000",
+            default_pay_amount: '1000000',
 
             ui_preferences: {
                 show_refresh: false,
@@ -139,7 +138,7 @@ export const TonJiggle: Story = {
 export const WithAppId: Story = {
     args: {
         options: {
-            app_id: "tonjiggle",
+            app_id: 'tonjiggle',
         },
     },
     decorators: [
@@ -154,7 +153,7 @@ export const WithAppId: Story = {
 export const HideSwapDetail: Story = {
     args: {
         options: {
-            app_id: "tonjiggle",
+            app_id: 'tonjiggle',
 
             ui_preferences: {
                 show_swap_details: false,
@@ -166,30 +165,30 @@ export const HideSwapDetail: Story = {
 
 export const Russian: Story = {
     args: {
-        locale: "ru",
+        locale: 'ru',
     },
 };
 
 export const Arabic: Story = {
     args: {
-        locale: "ar",
+        locale: 'ar',
     },
 };
 
 export const Spanish: Story = {
     args: {
-        locale: "es",
+        locale: 'es',
     },
 };
 
 export const SimplifiedChinese: Story = {
     args: {
-        locale: "cn",
+        locale: 'cn',
     },
 };
 
 export const Farsi: Story = {
     args: {
-        locale: "fa",
+        locale: 'fa',
     },
 };

--- a/lib/components/SwapCard/CardButton.tsx
+++ b/lib/components/SwapCard/CardButton.tsx
@@ -1,14 +1,14 @@
-import { FC, PropsWithChildren } from "react";
-import clsx from "clsx";
-import { MdKeyboardArrowDown } from "react-icons/md";
-import "./CardButton.scss";
-import { useOptionsStore } from "../../store/options.store";
-import { useTranslation } from "react-i18next";
-import { useSwapStore } from "../../store/swap.store";
+import { FC, PropsWithChildren } from 'react';
+import clsx from 'clsx';
+import { MdKeyboardArrowDown } from 'react-icons/md';
+import './CardButton.scss';
+import { useOptionsStore } from '../../store/options.store';
+import { useTranslation } from 'react-i18next';
+import { useSwapStore } from '../../store/swap.store';
 type CardButtonProps = {
     isLoading: boolean;
     onClick: () => void;
-    type: "pay" | "receive";
+    type: 'pay' | 'receive';
 };
 
 const CardButton: FC<CardButtonProps & PropsWithChildren> = ({
@@ -22,8 +22,8 @@ const CardButton: FC<CardButtonProps & PropsWithChildren> = ({
     const { isSelectingToken } = useSwapStore();
     const isDisabled = (() => {
         if (isSelectingToken) return true;
-        if (type === "pay" && options.lock_pay_token) return true;
-        if (type === "receive" && options.lock_receive_token) return true;
+        if (type === 'pay' && options.lock_pay_token) return true;
+        if (type === 'receive' && options.lock_receive_token) return true;
         return false;
     })();
     return (
@@ -31,42 +31,42 @@ const CardButton: FC<CardButtonProps & PropsWithChildren> = ({
             disabled={isDisabled}
             onClick={isDisabled ? () => {} : onClick}
             {...{
-                ...(isLoading && type === "pay"
-                    ? { "data-skeleton": true }
+                ...(isLoading && type === 'pay'
+                    ? { 'data-skeleton': true }
                     : {}),
             }}
             data-testid={`card-button-${type}`}
             className={clsx(
-                "selection-box-container",
-                isLoading && "loading",
-                type === "pay" && isLoading && "pay-loading",
-                type === "receive" && isLoading && "receive-loading"
+                'selection-box-container',
+                isLoading && 'loading',
+                type === 'pay' && isLoading && 'pay-loading',
+                type === 'receive' && isLoading && 'receive-loading'
             )}
             style={{
-                ...(isDisabled && { opacity: 0.7, cursor: "auto" }),
-                ...(isLoading && type === "pay"
+                ...(isDisabled && { opacity: 0.7, cursor: 'auto' }),
+                ...(isLoading && type === 'pay'
                     ? { color: `var(--text-black-color)` }
                     : {
                           background: `var(--input-token-color)`,
                           color: `var(--text-black-color)`,
                       }),
                 ...{
-                    "--skeleton-bg": `var(--input-token-color)`,
-                    "--skeleton-shine": `var(--skeleton-shine-color)`,
+                    '--skeleton-bg': `var(--input-token-color)`,
+                    '--skeleton-shine': `var(--skeleton-shine-color)`,
                 },
             }}
         >
             {!isLoading ? (
                 children
-            ) : type === "receive" ? (
+            ) : type === 'receive' ? (
                 <>
-                    {t("select")}{" "}
+                    {t('select')}{' '}
                     <div className="dropdown-icon">
                         <MdKeyboardArrowDown />
                     </div>
                 </>
             ) : (
-                ""
+                ''
             )}
         </button>
     );

--- a/lib/components/SwapCard/CardDialog.scss
+++ b/lib/components/SwapCard/CardDialog.scss
@@ -244,6 +244,7 @@
                 .tab-item {
                     position: relative;
                     transition: all 0.3s ease-in-out;
+                    background: transparent;
                     color: var(--text-black-color);
                     font-size: var(--font-size-base);
                     &.active {

--- a/lib/components/SwapCard/Token.tsx
+++ b/lib/components/SwapCard/Token.tsx
@@ -1,23 +1,23 @@
-import { Asset, fromNano } from "@mytonswap/sdk";
-import { useWalletStore } from "../../store/wallet.store";
-import { FC } from "react";
-import formatNumber from "../../utils/formatNum";
-import "./Token.scss";
-import { RiExternalLinkLine } from "react-icons/ri";
-import { PiStarBold } from "react-icons/pi";
+import { Asset, fromNano } from '@mytonswap/sdk';
+import { useWalletStore } from '../../store/wallet.store';
+import { FC } from 'react';
+import formatNumber from '../../utils/formatNum';
+import './Token.scss';
+import { RiExternalLinkLine } from 'react-icons/ri';
+import { PiStarBold } from 'react-icons/pi';
 
-import { PiStarFill } from "react-icons/pi";
+import { PiStarFill } from 'react-icons/pi';
 
-import { TokenTon } from "../icons/TokenTon";
-import { TON_ADDR } from "../../constants";
-import { toFixedDecimal } from "../../utils/toFixedDecimals";
-import { useFavoriteStore } from "../../store/favtorite.store";
-import clsx from "clsx";
-import { useSwapStore } from "../../store/swap.store";
+import { TokenTon } from '../icons/TokenTon';
+import { TON_ADDR } from '../../constants';
+import { toFixedDecimal } from '../../utils/toFixedDecimals';
+import { useFavoriteStore } from '../../store/favtorite.store';
+import clsx from 'clsx';
+import { useSwapStore } from '../../store/swap.store';
 type TokenProps = {
     asset: Asset;
     onTokenSelect: (asset: Asset) => void;
-    type: "pay" | "receive";
+    type: 'pay' | 'receive';
 };
 
 const Token: FC<TokenProps> = ({ asset, onTokenSelect, type }) => {
@@ -37,15 +37,14 @@ const Token: FC<TokenProps> = ({ asset, onTokenSelect, type }) => {
     const fixedPrice = price === 0 ? 0 : formatNumber(price, 2);
 
     const isSelected =
-        type === "pay"
+        type === 'pay'
             ? pay_token?.address === asset.address
             : receive_token?.address === asset.address ||
               pay_token?.address === asset.address;
-    console.log(type);
     return (
         <div
             onClick={isSelected ? undefined : () => onTokenSelect(asset)}
-            className={clsx("token-container", isSelected && "selected")}
+            className={clsx('token-container', isSelected && 'selected')}
             data-testid={asset.address}
         >
             <div className="token-content">
@@ -56,7 +55,7 @@ const Token: FC<TokenProps> = ({ asset, onTokenSelect, type }) => {
                 <div className="token-details">
                     <div className="token-details-symbol-balance">
                         <div className="symbol">
-                            {asset.symbol}{" "}
+                            {asset.symbol}{' '}
                             <span>
                                 <a
                                     href={`https://tonviewer.com/${asset.address}`}
@@ -82,7 +81,7 @@ const Token: FC<TokenProps> = ({ asset, onTokenSelect, type }) => {
                     </div>
                 </div>
                 <div>
-                    <div className={clsx("fav", isTokenFav && "faved")}>
+                    <div className={clsx('fav', isTokenFav && 'faved')}>
                         {isTokenFav ? (
                             <PiStarFill
                                 onClick={(e) => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@mytonswap/widget",
     "description": "MyTonSwap Widget - Easy to use swap widget for React on TON Blockchain",
-    "version": "2.0.19",
+    "version": "2.0.20",
     "type": "module",
     "author": {
         "name": "MyTonSwap",


### PR DESCRIPTION
This pull request focuses on standardizing the code style by ensuring consistent usage of single quotes for strings and making minor CSS adjustments. The most important changes include modifying string quotes across various files and adding a transparent background to specific CSS classes.

### Code Style Consistency:

* [`lib/components/Swap/Swap.stories.tsx`](diffhunk://#diff-8fd120b4a120681e0432b13af6de8dcbcdd8177c5b43bace10055c8bb67822c7L1-R5): Changed all double quotes to single quotes for string literals. [[1]](diffhunk://#diff-8fd120b4a120681e0432b13af6de8dcbcdd8177c5b43bace10055c8bb67822c7L1-R5) [[2]](diffhunk://#diff-8fd120b4a120681e0432b13af6de8dcbcdd8177c5b43bace10055c8bb67822c7L17-R18) [[3]](diffhunk://#diff-8fd120b4a120681e0432b13af6de8dcbcdd8177c5b43bace10055c8bb67822c7L55-R56) [[4]](diffhunk://#diff-8fd120b4a120681e0432b13af6de8dcbcdd8177c5b43bace10055c8bb67822c7L66-R67) [[5]](diffhunk://#diff-8fd120b4a120681e0432b13af6de8dcbcdd8177c5b43bace10055c8bb67822c7L77-R78) [[6]](diffhunk://#diff-8fd120b4a120681e0432b13af6de8dcbcdd8177c5b43bace10055c8bb67822c7L89-R94) [[7]](diffhunk://#diff-8fd120b4a120681e0432b13af6de8dcbcdd8177c5b43bace10055c8bb67822c7L114-R119) [[8]](diffhunk://#diff-8fd120b4a120681e0432b13af6de8dcbcdd8177c5b43bace10055c8bb67822c7L142-R141) [[9]](diffhunk://#diff-8fd120b4a120681e0432b13af6de8dcbcdd8177c5b43bace10055c8bb67822c7L157-R156) [[10]](diffhunk://#diff-8fd120b4a120681e0432b13af6de8dcbcdd8177c5b43bace10055c8bb67822c7L169-R192)
* [`lib/components/SwapCard/CardButton.tsx`](diffhunk://#diff-fa5f33f9d646be182ef38b3d7ed48baf25dc27c5cf148207474273baee88ce1eL1-R11): Updated string literals to use single quotes. [[1]](diffhunk://#diff-fa5f33f9d646be182ef38b3d7ed48baf25dc27c5cf148207474273baee88ce1eL1-R11) [[2]](diffhunk://#diff-fa5f33f9d646be182ef38b3d7ed48baf25dc27c5cf148207474273baee88ce1eL25-R69)
* [`lib/components/SwapCard/Token.tsx`](diffhunk://#diff-33714c52faf29b82704875113de16eaf9151a5402c98cfc9bf8b48e8905a2ea6L1-R20): Changed string literals to single quotes. [[1]](diffhunk://#diff-33714c52faf29b82704875113de16eaf9151a5402c98cfc9bf8b48e8905a2ea6L1-R20) [[2]](diffhunk://#diff-33714c52faf29b82704875113de16eaf9151a5402c98cfc9bf8b48e8905a2ea6L40-R47) [[3]](diffhunk://#diff-33714c52faf29b82704875113de16eaf9151a5402c98cfc9bf8b48e8905a2ea6L59-R58) [[4]](diffhunk://#diff-33714c52faf29b82704875113de16eaf9151a5402c98cfc9bf8b48e8905a2ea6L85-R84)

### CSS Adjustments:

* [`lib/components/Header/SettingPopover.scss`](diffhunk://#diff-9b1836ffb41d636f7ffbb3455e821c3aeecd2d5b9489744ee0ef92ad7de223f9R11): Added `background: transparent` to the `.modal-backdrop` class for better visual consistency.
* [`lib/components/Swap/Swap.scss`](diffhunk://#diff-1d0556178ac4b6875561a3ee12116fae987a8cdc4060283cc5b997b5dbe94f23L28): Removed `background: transparent` from button styles.
* [`lib/components/SwapCard/CardDialog.scss`](diffhunk://#diff-78cf38c8e9529803f541f63b364d1609bff0b146d46e5d96dae6ba105b551700R247): Added `background: transparent` to the `.tab-item` class to ensure a consistent look.