### PR TITLE
fix: global type conflict for telegram miniapps

### DIFF
--- a/lib/components/Swap/Swap.tsx
+++ b/lib/components/Swap/Swap.tsx
@@ -1,25 +1,25 @@
-import { FC, useEffect, useRef } from "react";
-import Header from "../Header/Header";
-import SwapCard from "../SwapCard/SwapCard";
-import SwapDetails from "../SwapDetails/SwapDetails";
-import clsx from "clsx";
-import { TonConnectUI } from "@tonconnect/ui-react";
-import { useOptionsStore, SwapOptions } from "../../store/options.store";
-import { ModalState, useSwapStore } from "../../store/swap.store";
-import { useWalletStore } from "../../store/wallet.store";
-import SwapButton from "../SwapButton/SwapButton";
-import "./Swap.scss";
-import { ErrorBoundary } from "react-error-boundary";
-import { Toaster } from "react-hot-toast";
-import "../../i18n/i18n";
+import { FC, useEffect, useRef } from 'react';
+import Header from '../Header/Header';
+import SwapCard from '../SwapCard/SwapCard';
+import SwapDetails from '../SwapDetails/SwapDetails';
+import clsx from 'clsx';
+import { TonConnectUI } from '@tonconnect/ui-react';
+import { useOptionsStore, SwapOptions } from '../../store/options.store';
+import { ModalState, useSwapStore } from '../../store/swap.store';
+import { useWalletStore } from '../../store/wallet.store';
+import SwapButton from '../SwapButton/SwapButton';
+import './Swap.scss';
+import { ErrorBoundary } from 'react-error-boundary';
+import { Toaster } from 'react-hot-toast';
+import '../../i18n/i18n';
 import {
     onSwap,
     onTokenSelect,
     useEventsStore,
-} from "../../store/events.store";
-import { useTranslation } from "react-i18next";
-import { cn } from "../../utils/cn";
-import { supportedLanguages } from "../../i18n/i18n";
+} from '../../store/events.store';
+import { useTranslation } from 'react-i18next';
+import { cn } from '../../utils/cn';
+import { supportedLanguages } from '../../i18n/i18n';
 
 export type SwapProps = {
     options?: SwapOptions;
@@ -30,14 +30,12 @@ export type SwapProps = {
 };
 
 // declare telegram in window
-declare global {
-    interface Window {
-        Telegram: {
-            WebApp: {
-                initData: string;
-            };
+interface NewWindow extends Window {
+    Telegram?: {
+        WebApp: {
+            initData: string;
         };
-    }
+    };
 }
 
 export const SwapComponent: FC<SwapProps> = ({
@@ -55,13 +53,13 @@ export const SwapComponent: FC<SwapProps> = ({
     ) {
         i18n.changeLanguage(locale);
     } else {
-        if (!locale && i18n.resolvedLanguage !== "en") {
-            i18n.changeLanguage("en");
+        if (!locale && i18n.resolvedLanguage !== 'en') {
+            i18n.changeLanguage('en');
         }
     }
     const direction = i18n.getResourceBundle(
         i18n.resolvedLanguage!,
-        "direction"
+        'direction'
     );
     const {
         setOptions,
@@ -119,7 +117,9 @@ export const SwapComponent: FC<SwapProps> = ({
                     }
                 }, 10000);
             }
-            if (window?.Telegram?.WebApp?.initData?.length !== 0) {
+            if (
+                (window as NewWindow)?.Telegram?.WebApp?.initData?.length !== 0
+            ) {
                 ensureDocumentIsScrollable();
             }
             function ensureDocumentIsScrollable() {
@@ -128,9 +128,9 @@ export const SwapComponent: FC<SwapProps> = ({
 
                 if (!isScrollable) {
                     document.documentElement.style.setProperty(
-                        "height",
-                        "calc(100vh + 1px)",
-                        "important"
+                        'height',
+                        'calc(100vh + 1px)',
+                        'important'
                     );
                 }
             }
@@ -154,21 +154,21 @@ export const SwapComponent: FC<SwapProps> = ({
 
     return (
         <ErrorBoundary fallback={<div>Something went wrong</div>}>
-            <div className={cn("mytonswap-app", direction)}>
-                <div className={clsx("container")}>
+            <div className={cn('mytonswap-app', direction)}>
+                <div className={clsx('container')}>
                     <Header />
                     <SwapCard />
                     {shouldShowSwapDetails && <SwapDetails />}
                     <SwapButton />
                     {shouldShowProvidedText && (
                         <div className="text-provided">
-                            {t("service_provided")}{" "}
+                            {t('service_provided')}{' '}
                             <a
                                 href="https://mytonswap.com"
                                 target="_blank"
                                 rel="noreferrer"
                             >
-                                {t("mytonswap")}
+                                {t('mytonswap')}
                             </a>
                         </div>
                     )}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@mytonswap/widget",
     "description": "MyTonSwap Widget - Easy to use swap widget for React on TON Blockchain",
-    "version": "2.0.22",
+    "version": "2.0.23",
     "type": "module",
     "author": {
         "name": "MyTonSwap",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@mytonswap/widget",
     "description": "MyTonSwap Widget - Easy to use swap widget for React on TON Blockchain",
-    "version": "2.0.21",
+    "version": "2.0.22",
     "type": "module",
     "author": {
         "name": "MyTonSwap",


### PR DESCRIPTION
This pull request to `lib/components/Swap/Swap.tsx` includes several changes aimed at code consistency and type safety improvements. The most important changes include converting double quotes to single quotes for consistency, updating the global `Window` interface, and ensuring type safety when accessing the `Telegram` object.

Code consistency improvements:

* Converted all double quotes to single quotes throughout the file for string literals. [[1]](diffhunk://#diff-087e34856d2793597eba9c015f477ba89d72f86b3b85beece3465b8ee23c17c8L1-R22) [[2]](diffhunk://#diff-087e34856d2793597eba9c015f477ba89d72f86b3b85beece3465b8ee23c17c8L58-R62) [[3]](diffhunk://#diff-087e34856d2793597eba9c015f477ba89d72f86b3b85beece3465b8ee23c17c8L131-R133) [[4]](diffhunk://#diff-087e34856d2793597eba9c015f477ba89d72f86b3b85beece3465b8ee23c17c8L157-R171)

Type safety improvements:

* Updated the global `Window` interface to a new `NewWindow` interface with an optional `Telegram` property.
* Ensured type safety when accessing the `Telegram` object by casting `window` to `NewWindow`.