### PR TITLE
Docker support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+
+services:
+    react-app:
+        build:
+            context: .
+            dockerfile: Dockerfile
+        ports:
+            - '6006:80'
+        restart: always

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@mytonswap/widget",
     "description": "MyTonSwap Widget - Easy to use swap widget for React on TON Blockchain",
-    "version": "2.0.29",
+    "version": "2.0.30",
     "type": "module",
     "author": {
         "name": "MyTonSwap",


### PR DESCRIPTION
This pull request includes changes to add Docker support for the project by introducing a `docker-compose.yml` file. The most important changes include specifying the Docker Compose version and defining a service for the React application.

Docker support:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R1-R10): Added Docker Compose configuration with version '3.8', defined a service named `react-app` with build context and Dockerfile, exposed port `6006` to `80`, and set the restart policy to always.